### PR TITLE
Fix comparison of identical string

### DIFF
--- a/src/xtd.tunit/include/xtd/tunit/assert.h
+++ b/src/xtd.tunit/include/xtd/tunit/assert.h
@@ -1282,7 +1282,7 @@ namespace xtd {
       
       /// @cond
       static void is_less_or_equal(const char* val1, const char* val2, const std::string& message, const xtd::tunit::line_info& line_info) {
-        if (strcmp(val1, val1) <= 0)
+        if (strcmp(val1, val2) <= 0)
           succeed(message, line_info);
         else
           base_assert::fail("less than or equal to " + base_assert::to_string(val2), base_assert::to_string(val1), message, line_info);
@@ -1303,7 +1303,7 @@ namespace xtd {
       }
 
       static void is_less_or_equal(const wchar_t* val1, const wchar_t* val2, const std::string& message, const xtd::tunit::line_info& line_info) {
-        if (wcscmp(val1, val1) <= 0)
+        if (wcscmp(val1, val2) <= 0)
           succeed(message, line_info);
         else
           base_assert::fail("less than or equal to " + base_assert::to_string(val2), base_assert::to_string(val1), message, line_info);


### PR DESCRIPTION
![cppcheck analysis xsd](https://user-images.githubusercontent.com/49657842/124908106-dab69800-dfe0-11eb-8638-d632ba6d6bf9.png)
is_less_or_equal assertion was comparing the same string against itself, thanks to cppcheck static analysis this was caught!
i think it will be worth it integrating a static analysis action to catch stuff like that in the future.
thanks again for the great job and have a nice day!<br>
