### PR TITLE
Removed identical extra condition

### DIFF
--- a/src/xtd.drawing/src/xtd/drawing/color.cpp
+++ b/src/xtd.drawing/src/xtd/drawing/color.cpp
@@ -218,8 +218,6 @@ color color::from_hsl(float hue, float saturation, float lightness) {
     return v1;
   };
   
-  if (saturation == 0) return color::from_argb(255, static_cast<uint8_t>(lightness * 255.0f), static_cast<uint8_t>(lightness * 255.0f), static_cast<uint8_t>(lightness * 255.0f));
-
   hue = hue / 360.0f;
   float v2 = (lightness < 0.5f) ? (lightness * (1 + saturation)) : ((lightness + saturation) - (lightness * saturation));
   float v1 = 2 * lightness - v2;


### PR DESCRIPTION
`if(saturation == 0)` condition was already dealt with at [drawing/color.cpp#210,](https://github.com/gammasoft71/xtd/blob/master/src/xtd.drawing/src/xtd/drawing/color.cpp#L210) the second one at [drawing/color.cpp#221](https://github.com/gammasoft71/xtd/blob/master/src/xtd.drawing/src/xtd/drawing/color.cpp#L221) seems to be redundant?