### PR TITLE
correction of my pr #8

### DIFF
--- a/src/xtd.core/src/xtd/net/sockets/socket.cpp
+++ b/src/xtd.core/src/xtd/net/sockets/socket.cpp
@@ -825,11 +825,11 @@ size_t socket::select(std::vector<socket>& check_read,std::vector<socket>& check
   int32_t status = native::socket::select(check_read_handles, check_write_handles, check_error_handles, microseconds);
   if (status < 0) throw socket_exception(get_last_error_(), csf_);
   
-  auto update_check_sockets = [](auto& sockets, auto& handles) {
-    for (size_t i = 0; i < handles.size(); i++)
-      if (handles[i] == 0)
-        sockets.erase(sockets.begin() + i);
-  };
+	auto update_check_sockets = [](auto& sockets, auto& handles) {
+		for (size_t i = 0, j = 0; i < handles.size() && j < sockets.size(); ++i, ++j)
+			if (handles[i] == 0)
+				sockets.erase(sockets.begin() + j--);
+	};
 
   update_check_sockets(check_read, check_read_handles);
   update_check_sockets(check_write, check_write_handles);


### PR DESCRIPTION
Okey so i had my doubts on the pull request i pushed lately, i made some tests and i found out it does not work properly.
the reason is when a socket is erased from the container `sockets`, the range of the container will change which will cause an invalid range exception on the next removals, at `sockets .begin() + i`  because `i` is responsible for the `handles` container.
This version adds another variable `j` which is responsible for the sockets range, so now this version is tested and it works fine.

## Old version
![BUG](https://user-images.githubusercontent.com/49657842/132045412-6da77129-3177-4f2c-997e-df6077171cc4.PNG)

## New version
![OK](https://user-images.githubusercontent.com/49657842/132045437-8a386dfd-8677-4201-8ccb-eb47eb12e7fe.PNG)
