### PR TITLE
Fixed date_time comparison

### DIFF
--- a/src/xtd.core/src/xtd/date_time.cpp
+++ b/src/xtd.core/src/xtd/date_time.cpp
@@ -287,8 +287,8 @@ int32_t date_time::compare_to(const object& obj) const noexcept {
 int32_t date_time::compare_to(const date_time& value) const noexcept {
   if (value_.count() < value.value_.count()) return -1;
   if (value_.count() > value.value_.count()) return 1;
-  if ( kind_ < value.kind_) return -1;
-  if (kind_ < value.kind_) return 1;
+  if (kind_ < value.kind_) return -1;
+  if (kind_ > value.kind_) return 1;
   return 0;
 }
 


### PR DESCRIPTION
cppcheck static code analyzer reported on an "identical condition 'kind_< value.kind_', second condition is always false"
<details>
  <summary>Full report</summary>
[C:\Users\bader\Desktop\xtd\src\xtd\src\xtd\system_report.cpp:152]: (style) Consider using std::copy algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:128] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\call_stack_msvc.cpp:62]: (style) The function 'OnCallstackEntry' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:130] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\call_stack_msvc.cpp:79]: (style) The function 'OnOutput' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:126] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\call_stack_msvc.cpp:82]: (style) The function 'OnSymInit' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:127] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\call_stack_msvc.cpp:85]: (style) The function 'OnLoadModule' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:129] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\call_stack_msvc.cpp:88]: (style) The function 'OnDbgHelpErr' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:714]: (warning) Class 'StackWalker' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:714]: (warning) Class 'StackWalker' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1069]: (portability) %d in format string (no. 4) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1069]: (portability) %d in format string (no. 5) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 4) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 5) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 8) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 9) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 10) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1075]: (portability) %d in format string (no. 11) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1095]: (portability) %d in format string (no. 2) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1102]: (portability) %d in format string (no. 2) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1108]: (portability) %d in format string (no. 2) requires 'int' but the argument type is 'DWORD {aka unsigned long}'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:696]: (style) C-style pointer casting
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:593]: (style) The scope of the variable 'fileVersion' can be reduced.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1081]: (style) The scope of the variable 'buffer' can be reduced.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.h:130] -> [C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:1137]: (style, inconclusive) Function 'OnOutput' argument 1 names different: declaration 'szText' definition 'buffer'.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:542]: (warning) Division by result of sizeof(). malloc() expects a size in bytes, did you intend to multiply instead?
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:57]: (style) struct member '_IMAGEHLP_LINE64::Key' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:60]: (style) struct member '_IMAGEHLP_LINE64::Address' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:65]: (style) struct member '_IMAGEHLP_MODULE64::ImageSize' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:66]: (style) struct member '_IMAGEHLP_MODULE64::TimeDateStamp' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:67]: (style) struct member '_IMAGEHLP_MODULE64::CheckSum' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:68]: (style) struct member '_IMAGEHLP_MODULE64::NumSyms' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:71]: (style) struct member '_IMAGEHLP_MODULE64::ImageName' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:90]: (style) struct member '_tagADDRESS64::Segment' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:94]: (style) struct member '_KDHELP64::Thread' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:95]: (style) struct member '_KDHELP64::ThCallbackStack' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:96]: (style) struct member '_KDHELP64::ThCallbackBStore' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:97]: (style) struct member '_KDHELP64::NextCallback' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:98]: (style) struct member '_KDHELP64::FramePointer' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:99]: (style) struct member '_KDHELP64::KiCallUserMode' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:100]: (style) struct member '_KDHELP64::KeUserCallbackDispatcher' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:101]: (style) struct member '_KDHELP64::SystemRangeStart' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:102]: (style) struct member '_KDHELP64::Reserved' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:110]: (style) struct member '_tagSTACKFRAME64::FuncTableEntry' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:111]: (style) struct member '_tagSTACKFRAME64::Params' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:112]: (style) struct member '_tagSTACKFRAME64::Far' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:113]: (style) struct member '_tagSTACKFRAME64::Virtual' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:114]: (style) struct member '_tagSTACKFRAME64::Reserved' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:426]: (style) struct member 'tagMODULEENTRY32::th32ModuleID' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:427]: (style) struct member 'tagMODULEENTRY32::th32ProcessID' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:428]: (style) struct member 'tagMODULEENTRY32::GlblcntUsage' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:429]: (style) struct member 'tagMODULEENTRY32::ProccntUsage' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:432]: (style) struct member 'tagMODULEENTRY32::hModule' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.3rdparty.call_stack\stack_walker.cpp:499]: (style) struct member '_MODULEINFO::EntryPoint' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:156]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:163]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:179]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:187]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:194]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:201]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:209]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:216]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:223]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:231]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:238]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:245]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:253]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:260]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:267]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:295]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:303]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:311]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:319]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:327]: (style) Class 'ustring' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:657]: (style) Class 'auto_delete_char_pointer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:33] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:1629]: (style, inconclusive) Function '__ustring_extract_format_arg' argument 2 names different: declaration 'format' definition 'formats'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:708] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:727]: (style) Local variable 'format' shadows outer function
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:412]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:413]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:420]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:421]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:424]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:425]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:428]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:429]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:765] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:714]: (warning) Missing bounds check for extra iterator increment in loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:721]: (warning) Possible dereference of an invalid iterator: iterator
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:350]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:357]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:364]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:483]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:490]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:497]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__format_stringer.h:212]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:30]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:32]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:33]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:34]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:42]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:48]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\internal\__parse.h:66]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\stack_trace.h:138]: (style) Class 'stack_trace' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object.h:97] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\stack_trace.h:324]: (style) The function 'to_string' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\stack_trace.cpp:44] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\stack_trace.h:296]: (style, inconclusive) Technically the member function 'xtd::diagnostics::stack_trace::get_frame' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\argument_exception.h:51]: (style) Class 'argument_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\argument_out_of_range_exception.h:50]: (style) Class 'argument_out_of_range_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\invalid_cast_exception.h:50]: (style) Class 'invalid_cast_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\arithmetic_exception.h:50]: (style) Class 'arithmetic_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\overflow_exception.h:50]: (style) Class 'overflow_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\convert_pointer.h:86]: (style) Parameter 'value' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:206]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:212]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:228]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:234]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:642]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:648]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:654]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:661]: (style, inconclusive) Technically the member function 'xtd::delegate::operator+' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:688]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:694]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:700]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:707]: (style, inconclusive) Technically the member function 'xtd::delegate::operator-' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:50]: (style) Class 'delegate' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:320]: (style) Class 'delegate' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\delegate.h:323]: (style) Class 'delegate' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\console_key_info.h:60]: (style, inconclusive) Technically the member function 'xtd::console_key_info::key' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\console_key_info.h:64]: (style, inconclusive) Technically the member function 'xtd::console_key_info::key_char' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\console_key_info.h:68]: (style, inconclusive) Technically the member function 'xtd::console_key_info::modifiers' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\argument_null_exception.h:50]: (style) Class 'argument_null_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\format_exception.h:50]: (style) Class 'format_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\convert.cpp:1080]: (style) Comparing expression of type 'signed long' against value 4294967295. Condition is always false.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\date_time.cpp:290] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\date_time.cpp:291]: (warning) Identical condition 'kind_<value.kind_', second condition is always false
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\guid.h:103]: (style) Struct 'guid' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\version.h:117]: (style) Class 'version' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\compiler.h:30]: (style) Class 'compiler' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object.h:97] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\compiler.h:68]: (style) The function 'to_string' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\compiler.h:82]: (information) Skipping configuration '_MSC_VER;__XTD_CORE_INTERNAL__' since the value of '_MSC_VER' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\compiler.h:86]: (information) Skipping configuration '__GNUC__;__XTD_CORE_INTERNAL__' since the value of '__GNUC__' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\cpp_language.h:30]: (style) Class 'cpp_language' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object.h:97] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\cpp_language.h:115]: (style) The function 'to_string' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\directory_info.h:245]: (style) Class 'directory_info' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object.h:97] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\operating_system.h:162]: (style) The function 'to_string' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object.h:97] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\processor.h:76]: (style) The function 'to_string' overrides a function in a base class but is not marked with a 'override' specifier.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\math.h:257] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\math.cpp:137]: (style, inconclusive) Function 'log' argument 2 names different: declaration 'new_base' definition 'newBase'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\time_zone_info.cpp:50]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\time_zone_info.cpp:124]: (style) Consider using std::find_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:550] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:576]: (style, inconclusive) Function 'compare_to' argument 1 names different: declaration 'tzi' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:673] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:638]: (style, inconclusive) Function 'equals' argument 1 names different: declaration 'tzi' definition 'other'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:674] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:642]: (style, inconclusive) Function 'equals' argument 1 names different: declaration 'obj' definition 'other'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\ustring.h:859] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:738]: (style, inconclusive) Function 'is_empty' argument 1 names different: declaration 'string' definition 'sttring'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:457]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:461]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:481]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:485]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:497]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:501]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:513]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:517]: (performance) Function parameter 'other' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:595]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:602]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:609]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:616]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:623]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:630]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:930]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:944]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\ustring.cpp:854]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\stream_reader.h:33]: (style) Class 'stream_reader' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\stream_reader.h:36]: (style) Class 'stream_reader' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\stream_writer.h:34]: (style) Class 'stream_writer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\stream_writer.h:37]: (style) Class 'stream_writer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_writer.cpp:36] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\stream_writer.h:83]: (style) Virtual function 'flush' is called from destructor '~stream_writer()' at line 36. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\path.h:156]: (style) Consider using std::accumulate algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\translator.cpp:40]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\version.cpp:103]: (error) Exception thrown in function declared not to throw exceptions.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\version.cpp:122]: (error) Exception thrown in function declared not to throw exceptions.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\version.h:222] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\version.cpp:61]: (style, inconclusive) Function 'compare_to' argument 1 names different: declaration 'version' definition 'obj'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\version.h:238] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\version.cpp:66]: (style, inconclusive) Function 'compare_to' argument 1 names different: declaration 'version' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\ostream_trace_listener.h:31]: (style) Class 'ostream_trace_listener' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\ostream_trace_listener.cpp:11] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\ostream_trace_listener.h:52]: (style) Virtual function 'flush' is called from destructor '~ostream_trace_listener()' at line 11. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\console_trace_listener.h:37]: (style) Class 'console_trace_listener' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_listener_collection.h:42]: (style) Class 'trace_listener_collection' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_listener_collection.h:45]: (style) Class 'trace_listener_collection' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\default_trace_listener.cpp:17] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\default_trace_listener.h:73]: (style, inconclusive) Technically the member function 'xtd::diagnostics::default_trace_listener::assert_ui_enabled' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\default_trace_listener.cpp:14] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\default_trace_listener.h:126]: (style) Virtual function 'flush' is called from destructor '~default_trace_listener()' at line 14. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\event_type_filter.h:32]: (style) Class 'event_type_filter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\data_received_event_args.h:34]: (style) Class 'data_received_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\invalid_operation_exception.h:50]: (style) Class 'invalid_operation_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\source_filter.h:33]: (style) Class 'source_filter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\source_switch.cpp:23] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\source_switch.h:64]: (style, inconclusive) Technically the member function 'xtd::diagnostics::source_switch::should_trace' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:444]: (style) Unused private function: 'trace::fail__'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:445]: (style) Unused private function: 'trace::fail__'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:446]: (style) Unused private function: 'trace::flush_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:448]: (style) Unused private function: 'trace::write_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:449]: (style) Unused private function: 'trace::write_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:447]: (style) Unused private function: 'trace::trace_event_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:450]: (style) Unused private function: 'trace::write_line_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace.h:451]: (style) Unused private function: 'trace::write_line_'
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_event_cache.cpp:8] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_event_cache.h:54]: (performance, inconclusive) Technically the member function 'xtd::diagnostics::trace_event_cache::call_stack' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_event_cache.cpp:22] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_event_cache.h:69]: (performance, inconclusive) Technically the member function 'xtd::diagnostics::trace_event_cache::process_id' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_event_cache.cpp:26] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_event_cache.h:74]: (performance, inconclusive) Technically the member function 'xtd::diagnostics::trace_event_cache::thread_id' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_event_cache.cpp:30] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_event_cache.h:79]: (performance, inconclusive) Technically the member function 'xtd::diagnostics::trace_event_cache::timestamp' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_listener.cpp:11]: (performance) Variable 'name_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_listener.cpp:7] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\diagnostics\trace_listener.h:120]: (style) Virtual function 'close' is called from destructor '~trace_listener()' at line 7. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_source.cpp:31] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\diagnostics\trace_source.cpp:30]: (style) The statement 'if (source_switch_!=source_switch) source_switch_=source_switch' is logically equivalent to 'source_switch_=source_switch'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:130]: (style) Class 'input_list' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:131]: (style) Class 'input_list' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:229] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:253]: (style) Local variable 'key' shadows outer function
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:177] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:178]: (warning) Either the condition 'iterator!=value.end()' is redundant or there is possible dereference of an invalid iterator: iterator+1.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:169]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:180]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_gcc.cpp:183]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\internal\__opaque_console_win32.cpp:47]: (performance, inconclusive) Technically the member function '::terminal::force_compiler_optimizer_to_create_object' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_reader.cpp:13]: (warning) Class 'binary_reader' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_reader.cpp:13]: (warning) Class 'binary_reader' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_reader.cpp:22] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_reader.cpp:23]: (style) Condition 'stream_' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\binary_reader.h:44]: (style) Class 'binary_reader' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\binary_reader.h:51]: (style) Class 'binary_reader' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\io_exception.h:57]: (style) Class 'io_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\end_of_stream_exception.h:57]: (style) Class 'end_of_stream_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\file_not_found_exception.h:57]: (style) Class 'file_not_found_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_writer.cpp:14]: (warning) Class 'binary_writer' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_writer.cpp:14]: (warning) Class 'binary_writer' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\binary_writer.cpp:29] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\binary_writer.h:71]: (style) Virtual function 'flush' is called from destructor '~binary_writer()' at line 29. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\binary_writer.h:45]: (style) Class 'binary_writer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\binary_writer.h:48]: (style) Class 'binary_writer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\unauthorized_access_exception.h:51]: (style) Class 'unauthorized_access_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\file_info.h:62]: (style) Class 'file_info' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\directory_not_found_exception.h:57]: (style) Class 'directory_not_found_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\drive_info.h:46]: (style) Class 'drive_info' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\path_too_long_exception.h:57]: (style) Class 'path_too_long_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\not_supported_exception.h:50]: (style) Class 'not_supported_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\directory.cpp:261]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\drive_info.cpp:71]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\security\security_exception.h:52]: (style) Class 'security_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\not_implemented_exception.h:50]: (style) Class 'not_implemented_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file.cpp:220]: (style) Unused variable: contents
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\platform_not_supported_exception.h:50]: (style) Class 'platform_not_supported_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:20] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:21]: (style) Condition 'result!=0' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:32] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:33]: (style) Condition 'result!=0' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:52] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:53]: (style) Condition 'result!=0' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:64] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\file_system_info.cpp:65]: (style) Condition 'result!=0' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_reader.cpp:11]: (warning) Class 'stream_reader' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_reader.cpp:11]: (warning) Class 'stream_reader' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_reader.cpp:20] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_reader.cpp:21]: (style) Condition 'stream_' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\string_reader.h:31]: (style) Class 'string_reader' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_writer.cpp:20]: (warning) Class 'stream_writer' does not have a copy constructor which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\stream_writer.cpp:20]: (warning) Class 'stream_writer' does not have a operator= which is recommended since it has dynamic memory/resource allocation(s).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\io\string_writer.cpp:8] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\string_writer.h:59]: (style) Virtual function 'write' is called from constructor 'string_writer(const xtd::ustring&str)' at line 8. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\io\string_writer.h:33]: (style) Class 'string_writer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket_exception.h:60]: (style) Class 'socket_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\ip_address.h:233] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\ip_address.cpp:187]: (style, inconclusive) Function 'network_to_host_order' argument 1 names different: declaration 'host' definition 'network'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\ip_end_point.h:62] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\ip_end_point.cpp:22]: (style, inconclusive) Function 'address' argument 1 names different: declaration 'value' definition 'address'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\ip_end_point.h:69] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\ip_end_point.cpp:32]: (style, inconclusive) Function 'port' argument 1 names different: declaration 'value' definition 'port'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\index_out_of_range_exception.h:50]: (style) Class 'index_out_of_range_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\ip_v6_multicast_option.h:38]: (style) Class 'ip_v6_multicast_option' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\multicast_option.h:49]: (style) Class 'multicast_option' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:115]: (warning) Member variable 'async_result_receive_message_from::socket_flags_' is not initialized in the constructor.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:145]: (style) Class 'socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:149]: (style) Class 'socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:71]: (style) Class 'async_result_socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:86]: (style) Class 'async_result_accept' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:92]: (style) Class 'async_result_connect' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:97]: (style) Class 'async_result_disconnect' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:102]: (style) Class 'async_result_receive' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:108]: (style) Class 'async_result_receive_from' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:115]: (style) Class 'async_result_receive_message_from' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:124]: (style) Class 'async_result_send' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:130]: (style) Class 'async_result_send_to' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:582] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:861]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_accept' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:590] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:872]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_connect' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:597] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:881]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_disconnect' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:604] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:897]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_receive' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:612] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:912]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_receive' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:621] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:925]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_receive_from' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:630] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:940]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_receive_message_from' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:641] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:956]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_send' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:649] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:972]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_send' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:658] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:985]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::socket::end_send_to' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\network_stream.h:55]: (style) Class 'network_stream' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\send_packets_element.h:56]: (style) Class 'send_packets_element' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\send_packets_element.h:102]: (style) Class 'send_packets_element' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\send_packets_element.h:107]: (style) Class 'send_packets_element' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket_async_event_args.h:67]: (style) Class 'socket_async_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket_async_event_args.h:109] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket_async_event_args.cpp:30]: (warning) Function 'set_buffer' argument order different: declaration 'offset, count' definition 'count, offset'
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket_async_event_args.h:117] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket_async_event_args.cpp:34]: (warning) Function 'set_buffer' argument order different: declaration 'buffer, count, offset' definition 'buffer, offset, count'
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:17]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:21]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:32]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:180]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_client.h:57] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:20]: (style, inconclusive) Function 'tcp_client' argument 1 names different: declaration 'end_point' definition 'local_end_point'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_client.h:317] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_client.cpp:154]: (style, inconclusive) Function 'connect' argument 1 names different: declaration 'hostname' definition 'host_name'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_client.h:57]: (style) Class 'tcp_client' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_client.h:60]: (style) Class 'tcp_client' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_client.h:353]: (style) Class 'tcp_client' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_listener.cpp:20]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_listener.cpp:131]: (style) Throwing a copy of the caught exception instead of rethrowing the original exception.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_listener.cpp:99] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_listener.h:197]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::tcp_listener::end_accept_socket' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\tcp_listener.cpp:107] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_listener.h:209]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::tcp_listener::end_accept_tcp_client' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_listener.h:38]: (style) Class 'async_result_socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_listener.h:53]: (style) Class 'async_result_accept_socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\tcp_listener.h:59]: (style) Class 'async_result_accept_tcp_client' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:52]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:75]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:744] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:488]: (style, inconclusive) Function 'begin_send' argument 5 names different: declaration 'error_code' definition 'error'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:861] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:582]: (style, inconclusive) Function 'end_accept' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:872] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:590]: (style, inconclusive) Function 'end_connect' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:881] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:597]: (style, inconclusive) Function 'end_disconnect' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:897] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:604]: (style, inconclusive) Function 'end_receive' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:912] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:612]: (style, inconclusive) Function 'end_receive' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:912] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:612]: (style, inconclusive) Function 'end_receive' argument 2 names different: declaration 'error_code' definition 'error'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:925] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:621]: (style, inconclusive) Function 'end_receive_from' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:940] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:630]: (style, inconclusive) Function 'end_receive_message_from' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:956] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:641]: (style, inconclusive) Function 'end_send' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:972] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:649]: (style, inconclusive) Function 'end_send' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:972] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:649]: (style, inconclusive) Function 'end_send' argument 2 names different: declaration 'error_code' definition 'error'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:985] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:658]: (style, inconclusive) Function 'end_send_to' argument 1 names different: declaration 'async_result' definition 'ar'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\socket.h:1161] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:765]: (style, inconclusive) Function 'receive' argument 5 names different: declaration 'error' definition 'error_code'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:495]: (performance) Function parameter 'buffer' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:915]: (performance) Function parameter 'option_value' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:923]: (performance) Function parameter 'option_value' should be passed by const reference.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:816]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:820]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\socket.cpp:824]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\object_closed_exception.h:50]: (style) Class 'object_closed_exception' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:65]: (warning) Member variable 'async_result_send::number_of_bytes_sent_' is not initialized in the constructor.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:229] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:367]: (performance, inconclusive) Technically the member function 'xtd::net::sockets::udp_client::end_send' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:43]: (style) Class 'async_result_socket' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:58]: (style) Class 'async_result_receive' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:65]: (style) Class 'async_result_send' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:22]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:27]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:32]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:51]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:101] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:37]: (style, inconclusive) Function 'udp_client' argument 1 names different: declaration 'address_Family' definition 'address_family'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\include\xtd\net\sockets\udp_client.h:111] -> [C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:43]: (style, inconclusive) Function 'udp_client' argument 2 names different: declaration 'addressFamily' definition 'address_family'.
[C:\Users\bader\Desktop\xtd\src\xtd.core\src\xtd\net\sockets\udp_client.cpp:15]: (style) struct member 'data::max_udp_size' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:133]: (style) Class 'input_list' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:134]: (style) Class 'input_list' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:228] -> [C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:248]: (style) Local variable 'key' shadows outer function
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:180] -> [C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:181]: (warning) Either the condition 'iterator!=value.end()' is redundant or there is possible dereference of an invalid iterator: iterator+1.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:378]: (style) struct member 'key_key_char::alt' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:379]: (style) struct member 'key_key_char::control' is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:172]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:183]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\console.cpp:186]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\date_time.cpp:250]: (style) Clarify calculation precedence for '-' and '?'.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\date_time.cpp:239]: (style) Consider using std::find_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\include\xtd\native\unix\strings.h:131]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\include\xtd\native\unix\strings.h:112]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\file_system.cpp:20]: (style, inconclusive) Technically the member function 'get_attributes::system_attribute_to_file_attribute_converter::operator()' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\process.cpp:30]: (style) Class 'file_descriptor_streambuf' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\process.cpp:57]: (style) Class 'process_istream' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\process.cpp:65]: (style) Class 'process_ostream' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\process.cpp:108]: (performance) Inefficient usage of string::find() in condition; string::starts_with() could be faster.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.unix\src\xtd\native\unix\process.cpp:108]: (style) Consider using std::any_of algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\console.cpp:51]: (performance, inconclusive) Technically the member function '::terminal::force_compiler_optimizer_to_create_object' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\include\xtd\native\win32\strings.h:82]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\include\xtd\native\win32\strings.h:62]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\environment.cpp:97]: (information) GetVersionEx may be altered or unavailable for releases after Windows 8.1. Instead, use the Version Helper functions
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\environment.cpp:111]: (information) GetVersionEx may be altered or unavailable for releases after Windows 8.1. Instead, use the Version Helper functions
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\date_time.cpp:257]: (style) Clarify calculation precedence for '-' and '?'.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\date_time.cpp:246]: (style) Consider using std::find_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\process.cpp:21]: (style) Class 'file_handle_streambuf' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\process.cpp:51]: (style) Class 'process_istream' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.core.native.win32\src\xtd\native\win32\process.cpp:59]: (style) Class 'process_ostream' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\brush.h:77] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\solid_brush.h:49]: (warning) The class 'solid_brush' defines member variable with name 'data_' also defined in its parent class 'brush'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\solid_brush.h:27]: (style) Class 'solid_brush' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\image.h:49] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\bitmap.h:25]: (warning) The class 'bitmap' defines member variable with name 'empty' also defined in its parent class 'image'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\font_family.h:40]: (style) Class 'font_family' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\font_family.h:44]: (style) Class 'font_family' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\pen.h:38]: (style) Class 'pen' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\pen.h:50]: (style) Class 'pen' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\point.h:133]: (style) Class 'point' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\graphics.h:254]: (style) Class 'graphics' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\color.h:1223] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\color.cpp:159]: (style, inconclusive) Function 'color' argument 2 names different: declaration 'know_color' definition 'known_color'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\font_family.cpp:28]: (style) Consider using std::find_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\font.h:320]: (style) Class 'font' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\font.h:320] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\font.cpp:49]: (style, inconclusive) Function 'font' argument 1 names different: declaration 'hfont' definition 'handle'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\graphics.cpp:124] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\graphics.cpp:123]: (style, inconclusive) Found duplicate branches for 'if' and 'else'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\pen.cpp:56] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\pen.cpp:55]: (style) The statement 'if (data_->alignment_!=alignment) data_->alignment_=alignment' is logically equivalent to 'data_->alignment_=alignment'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\pen.cpp:115] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\pen.cpp:114]: (style) The statement 'if (data_->type_!=type) data_->type_=type' is logically equivalent to 'data_->type_=type'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\image.h:173] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\image.cpp:35]: (style, inconclusive) Function 'image' argument 1 names different: declaration 'fileName' definition 'filename'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\point.h:133] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\point.cpp:10]: (style, inconclusive) Function 'point' argument 1 names different: declaration 'sz' definition 'size'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\size.h:110] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\size.cpp:47]: (style, inconclusive) Function 'subtract' argument 1 names different: declaration 'sz1' definition 'size1'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\size.h:110] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\size.cpp:47]: (style, inconclusive) Function 'subtract' argument 2 names different: declaration 'sz2' definition 'size2'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\size_f.h:102] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\size_f.cpp:35]: (style, inconclusive) Function 'subtract' argument 1 names different: declaration 'sz1' definition 'size1'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\size_f.h:102] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\size_f.cpp:35]: (style, inconclusive) Function 'subtract' argument 2 names different: declaration 'sz2' definition 'size2'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\solid_brush.cpp:22]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\texture_brush.cpp:21]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\brush.h:77] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\texture_brush.h:49]: (warning) The class 'texture_brush' defines member variable with name 'data_' also defined in its parent class 'brush'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\texture_brush.h:27]: (style) Class 'texture_brush' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\system_images.cpp:89]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\system_images.cpp:115]: (style) Consider using std::copy algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\drawing2d\hatch_brush.cpp:544]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\brush.h:77] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\drawing2d\hatch_brush.h:79]: (warning) The class 'hatch_brush' defines member variable with name 'data_' also defined in its parent class 'brush'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\drawing2d\linear_gradient_brush.cpp:38]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\brush.h:77] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing\include\xtd\drawing\drawing2d\linear_gradient_brush.h:137]: (warning) The class 'linear_gradient_brush' defines member variable with name 'data_' also defined in its parent class 'brush'.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing\src\xtd\drawing\text\installed_font_collection.cpp:12]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\src\xtd\drawing\native\wxwidgets\icon.cpp:20]: (style) Class 'StdInputStreamAdapter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\src\xtd\drawing\native\wxwidgets\icon.cpp:49]: (style) Class 'StdOutputStreamAdapter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\src\xtd\drawing\native\wxwidgets\graphics.cpp:21]: (style) Class 'graphics_context' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\include\xtd\drawing\native\hdc_wrapper.h:32] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\include\xtd\drawing\native\hdc_wrapper.h:36]: (style) Local variable 'hdc' shadows outer function
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\include\xtd\drawing\native\hdc_wrapper.h:32] -> [C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\include\xtd\drawing\native\hdc_wrapper.h:42]: (style) Local variable 'hdc' shadows outer function
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\src\xtd\drawing\native\wxwidgets\image.cpp:20]: (style) Class 'StdInputStreamAdapter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.drawing.native.wxwidgets\src\xtd\drawing\native\wxwidgets\image.cpp:49]: (style) Class 'StdOutputStreamAdapter' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\iwin32_window.h:19]: (information) The code 'class iwin32_window interface_ {' is not handled. You can use -I or --include to add handling of this code.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\ibutton_control.h:22]: (information) The code 'class ibutton_control interface_ {' is not handled. You can use -I or --include to add handling of this code.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\imessage_filter.h:20]: (information) The code 'class imessage_filter interface_ {' is not handled. You can use -I or --include to add handling of this code.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < std :: reference_wrapper < menu_item > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:38]: (style) Class 'value_type' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < std :: reference_wrapper < control > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:409]: (style) Consider using std::copy algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:323]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:332]: (performance) Prefer prefix ++/-- operators for non-primitive types.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < drawing :: image , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < drawing :: image , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < drawing :: image , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < drawing :: image , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < drawing :: image , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < drawing :: image , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < std :: reference_wrapper < tool_bar_item > , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < xtd :: ustring , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < xtd :: ustring , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: ustring , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < xtd :: ustring , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < xtd :: forms :: link , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < xtd :: forms :: link , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < xtd :: forms :: link , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < xtd :: forms :: link , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < xtd :: ustring , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < xtd :: ustring , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < xtd :: forms :: link , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < xtd :: forms :: link , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_added' is not assigned a value in 'arranged_element_collection < item , item :: sorter >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_updated' is not assigned a value in 'arranged_element_collection < item , item :: sorter >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , item :: sorter >::item_removed' is not assigned a value in 'arranged_element_collection < item , item :: sorter >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < item , item :: sorter >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < item , item :: sorter >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_added' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_updated' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:115]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_removed' is not assigned in the copy constructor. Should it be copied?
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_added' is not assigned a value in 'arranged_element_collection < item , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_updated' is not assigned a value in 'arranged_element_collection < item , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:116]: (warning, inconclusive) Member variable 'arranged_element_collection < item , sorter_none >::item_removed' is not assigned a value in 'arranged_element_collection < item , sorter_none >::operator='.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:104]: (style) Class 'arranged_element_collection < item , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\layout\arranged_element_collection.h:111]: (style) Class 'arranged_element_collection < item , sorter_none >' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_base.h:26] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_colors.h:26]: (warning) The class 'theme_colors' defines member variable with name 'empty' also defined in its parent class 'theme_base'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\context_menu.h:31]: (style) Class 'context_menu' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\context_menu.h:35]: (style) Class 'context_menu' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\context_menu.cpp:31] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\context_menu.h:44]: (style) Virtual function 'destroy_menu_handle' is called from destructor '~context_menu()' at line 31. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control_event_args.h:35]: (style) Class 'control_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\key_event_args.h:31]: (style) Class 'key_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\key_press_event_args.h:34]: (style) Class 'key_press_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\padding.h:38]: (style) Class 'padding' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:121]: (style) Class 'async_result_invoke' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:154]: (style) Class 'control_collection' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:115] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:848]: (style) Virtual function 'destroy_control' is called from destructor '~control()' at line 115. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\application.cpp:32]: (performance, inconclusive) Technically the member function '__init_process_message_box_message__::__show_message_box__' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\application.cpp:36]: (performance, inconclusive) Technically the member function '__init_process_message_box_message__::__force_compiler_optimizer_to_create_object__' can be static (but you may consider moving to unnamed namespace).
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\application.cpp:119]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_base.h:26] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_images.h:25]: (warning) The class 'theme_images' defines member variable with name 'empty' also defined in its parent class 'theme_base'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_base.h:26] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_renderers.h:25]: (warning) The class 'theme_renderers' defines member variable with name 'empty' also defined in its parent class 'theme_base'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\form_closing_event_args.h:29]: (style) Class 'form_closing_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\menu_item.h:39]: (style) Class 'menu_item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\main_menu.h:41]: (style) Class 'main_menu' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\main_menu.h:45]: (style) Class 'main_menu' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\tool_bar_button.h:27]: (style) Class 'tool_bar_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\tool_bar_button.h:29]: (style) Class 'tool_bar_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\help_event_args.h:29]: (style) Class 'help_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button_base.h:48] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button_base.h:47]: (style) The statement 'if (data_->auto_ellipsis!=auto_ellipsis) data_->auto_ellipsis=auto_ellipsis' is logically equivalent to 'data_->auto_ellipsis=auto_ellipsis'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button.h:105] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button.h:104]: (style) The statement 'if (data_->auto_repeat_delay!=auto_repeat_delay) data_->auto_repeat_delay=auto_repeat_delay' is logically equivalent to 'data_->auto_repeat_delay=auto_repeat_delay'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button.h:117] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button.h:116]: (style) The statement 'if (data_->auto_repeat_interval!=auto_repeat_interval) data_->auto_repeat_interval=auto_repeat_interval' is logically equivalent to 'data_->auto_repeat_interval=auto_repeat_interval'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:49] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:48]: (style) The statement 'if (theme_colors_!=theme_colors) theme_colors_=theme_colors' is logically equivalent to 'theme_colors_=theme_colors'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:57] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:56]: (style) The statement 'if (theme_images_!=theme_images) theme_images_=theme_images' is logically equivalent to 'theme_images_=theme_images'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:65] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:64]: (style) The statement 'if (theme_renderers_!=theme_renderers) theme_renderers_=theme_renderers' is logically equivalent to 'theme_renderers_=theme_renderers'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\exception_dialog.h:77] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\exception_dialog.h:76]: (style) The statement 'if (text_!=text) text_=text' is logically equivalent to 'text_=text'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:54] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:53]: (style) The statement 'if (buttons_!=buttons) buttons_=buttons' is logically equivalent to 'buttons_=buttons'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:66] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:65]: (style) The statement 'if (default_button_!=default_button) default_button_=default_button' is logically equivalent to 'default_button_=default_button'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:78] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:77]: (style) The statement 'if (display_help_button_!=display_help_button) display_help_button_=display_help_button' is logically equivalent to 'display_help_button_=display_help_button'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:94] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:93]: (style) The statement 'if (dialog_style_!=dialog_style) dialog_style_=dialog_style' is logically equivalent to 'dialog_style_=dialog_style'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:106] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:105]: (style) The statement 'if (icon_!=icon) icon_=icon' is logically equivalent to 'icon_=icon'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:118] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:117]: (style) The statement 'if (options_!=options) options_=options' is logically equivalent to 'options_=options'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:130] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:129]: (style) The statement 'if (message_!=message) message_=message' is logically equivalent to 'message_=message'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:142] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\message_dialog.h:141]: (style) The statement 'if (text_!=text) text_=text' is logically equivalent to 'text_=text'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\image_list.h:91]: (style) Parameter 'tag' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control_layout_style.h:26]: (style) Class 'control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control_layout_style.h:29]: (style) Class 'control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control_layout_style.h:33]: (style) Class 'control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\horizontal_control_layout_style.h:24]: (style) Class 'horizontal_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\horizontal_control_layout_style.h:27]: (style) Class 'horizontal_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\horizontal_control_layout_style.h:30]: (style) Class 'horizontal_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\horizontal_control_layout_style.h:41]: (style) Class 'horizontal_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\horizontal_control_layout_style.h:52]: (style) Class 'horizontal_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\link_label.h:63]: (style) Class 'link_collection' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\do_work_event_args.h:31]: (style) Class 'do_work_event_args' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\button.cpp:28] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\button.cpp:27]: (style) The statement 'if (data_->dialog_result!=dialog_result) data_->dialog_result=dialog_result' is logically equivalent to 'data_->dialog_result=dialog_result'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\button_base.h:120] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\button_base.cpp:60]: (style, inconclusive) Function 'text_align' argument 1 names different: declaration 'value' definition 'text_align'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box_renderer.cpp:229] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box_renderer.cpp:232]: (style) Condition 'state==xtd::forms::visual_styles::check_box_state::unchecked_hot' is always false
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box_renderer.cpp:149]: (style) Variable 'background_color' is assigned a value that is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box_renderer.cpp:182]: (style) Variable 'background_color' is assigned a value that is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box.cpp:51] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\check_box.cpp:50]: (style) The statement 'if (data_->auto_check!=auto_check) data_->auto_check=auto_check' is logically equivalent to 'data_->auto_check=auto_check'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\list_control.h:35]: (style, inconclusive) Technically the member function 'xtd::forms::list_control::item::sorter::operator()' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\list_control.h:48]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\list_control.h:56]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\checked_list_box.h:38]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\checked_list_box.h:64]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\checked_list_box.cpp:55]: (style) Consider using std::copy_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\checked_list_box.cpp:98]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\color_picker.h:41] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\color_picker.cpp:18]: (style, inconclusive) Function 'color' argument 1 names different: declaration 'color' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\xtd_forms_common_dialog_closed_caller.h:5]: (style) Struct '__xtd_forms_common_dialog_closed_caller__' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\command_link_button.cpp:36] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\command_link_button.cpp:37]: (style) The if condition is the same as the previous if condition
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\country.cpp:28]: (style) Consider using std::find_if algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:53]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:57]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:61]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:81]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:87]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:93]: (style) Class 'emoticon' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:68]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:74]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:83]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\emoticon.h:89]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\domain_up_down.h:32]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\domain_up_down.h:40]: (style) Class 'item' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:490] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:489]: (style) The statement 'if (data_->margin!=margin) data_->margin=margin' is logically equivalent to 'data_->margin=margin'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:569] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:568]: (style) The statement 'if (data_->padding!=padding) data_->padding=padding' is logically equivalent to 'data_->padding=padding'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:584] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:578] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:584]: (style) Condition 'data_->parent==0' is always true
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:998] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:1211]: (style, inconclusive) Function 'set_auto_size_mode' argument 1 names different: declaration 'auto_size_mode' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:1810] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:1283]: (style, inconclusive) Function 'wnd_proc' argument 1 names different: declaration 'm' definition 'message'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:1613]: (style) Parameter 'message' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\control.cpp:1619]: (style) Parameter 'message' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\control.h:1228] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\font_picker.h:59]: (warning) The class 'font_picker' defines member variable with name 'font_changed' also defined in its parent class 'control'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\font_picker.cpp:39] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\font_picker.cpp:40]: (style) The if condition is the same as the previous if condition
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\font_picker.h:40] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\font_picker.cpp:13]: (style, inconclusive) Function 'color' argument 1 names different: declaration 'color' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\font_picker.h:50] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\font_picker.cpp:22]: (style, inconclusive) Function 'font' argument 1 names different: declaration 'font' definition 'value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:322]: (style) Boolean result is used in bitwise operation. Clarify expression with parentheses.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:87] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:86]: (style) The statement 'if (dialog_result_!=value) dialog_result_=value' is logically equivalent to 'dialog_result_=value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:170] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:169]: (style) The statement 'if (start_position_!=start_position) start_position_=start_position' is logically equivalent to 'start_position_=start_position'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:277] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:279]: (style) Redundant initialization for 'result'. The initialized value is overwritten before it is read.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:291] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:293]: (style) Redundant initialization for 'result'. The initialized value is overwritten before it is read.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:314] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:316]: (style) Redundant initialization for 'result'. The initialized value is overwritten before it is read.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\form.h:60] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:37]: (style, inconclusive) Function 'accept_button' argument 1 names different: declaration 'value' definition 'accept_button'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\form.h:84] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:52]: (style, inconclusive) Function 'cancel_button' argument 1 names different: declaration 'value' definition 'cancel_button'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\form.h:183] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:155]: (style, inconclusive) Function 'parent' argument 1 names different: declaration 'value' definition 'parent'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\form.h:199] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\form.cpp:168]: (style, inconclusive) Function 'start_position' argument 1 names different: declaration 'value' definition 'start_position'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\horizontal_layout_panel.cpp:57]: (style) The scope of the variable 'height' can be reduced.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\lcd_label.h:33]: (information) The code 'class idigit interface_ {' is not handled. You can use -I or --include to add handling of this code.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:68] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:67]: (style) The statement 'if (dialog_style_!=dialog_style) dialog_style_=dialog_style' is logically equivalent to 'dialog_style_=dialog_style'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:82] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:81]: (style) The statement 'if (multiline_!=multiline) multiline_=multiline' is logically equivalent to 'multiline_=multiline'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:94] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:93]: (style) The statement 'if (message_!=message) message_=message' is logically equivalent to 'message_=message'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:106] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:105]: (style) The statement 'if (text_!=text) text_=text' is logically equivalent to 'text_=text'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:150] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\input_dialog.h:149]: (style) The statement 'if (word_wrap_!=word_wrap) word_wrap_=word_wrap' is logically equivalent to 'word_wrap_=word_wrap'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\light_button.cpp:43] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\light_button.cpp:42]: (style) The statement 'if (data_->auto_check!=auto_check) data_->auto_check=auto_check' is logically equivalent to 'data_->auto_check=auto_check'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\link_label.cpp:35]: (performance) Variable 'active_link_color_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\link_label.cpp:36]: (style) Same expression in both branches of ternary operator.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\link_label.h:154] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\link_label.cpp:240]: (style, inconclusive) Function 'get_text_location' argument 1 names different: declaration 'line' definition 'line_number'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\link_label.cpp:243]: (style) Unused variable: text_rects
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\list_box.cpp:102]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\menu.cpp:20]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\menu.cpp:43]: (performance) Variable 'data_' is assigned in constructor body. Consider performing initialization in initialization list.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\menu.cpp:53] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\menu.h:208]: (style) Virtual function 'destroy_menu' is called from destructor '~menu()' at line 53. Dynamic binding is not used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\numeric_up_down.cpp:62] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\numeric_up_down.cpp:64]: (style) Variable 'value_' is reassigned a value before the old one has been used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\xtd_forms_message_dialog_closed_caller.h:5]: (style) Struct '__xtd_forms_message_dialog_closed_caller__' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\open_file_dialog.h:52] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\open_file_dialog.cpp:11]: (style, inconclusive) Function 'run_file_dialog' argument 1 names different: declaration 'hwnd_owner' definition 'owner'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_dialog.cpp:124] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_dialog.cpp:123]: (style) The statement 'if (step_!=step) step_=step' is logically equivalent to 'step_=step'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_dialog.cpp:130] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_dialog.cpp:131]: (style) Variable 'value_' is reassigned a value before the old one has been used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_bar.cpp:52] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_bar.cpp:51]: (style) The statement 'if (step_!=step) step_=step' is logically equivalent to 'step_=step'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_bar.cpp:69] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\progress_bar.cpp:71]: (style) Variable 'value_' is reassigned a value before the old one has been used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button_renderer.cpp:191] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button_renderer.cpp:194]: (style) Condition 'state==xtd::forms::visual_styles::radio_button_state::unchecked_hot' is always false
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button_renderer.cpp:225] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button_renderer.cpp:228]: (style) Condition 'state==xtd::forms::visual_styles::radio_button_state::unchecked_hot' is always false
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button_renderer.cpp:142]: (style) Variable 'background_color' is assigned a value that is never used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button.cpp:47] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button.cpp:46]: (style) The statement 'if (auto_check_!=auto_check) auto_check_=auto_check' is logically equivalent to 'auto_check_=auto_check'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button.cpp:136]: (style) Parameter 'message' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\radio_button.cpp:143]: (style) Parameter 'message' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:18] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:17]: (style) The statement 'if (large_change_!=large_change) large_change_=large_change' is logically equivalent to 'large_change_=large_change'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:28] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:27]: (style) The statement 'if (maximum_!=maximum) maximum_=maximum' is logically equivalent to 'maximum_=maximum'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:38] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:37]: (style) The statement 'if (minimum_!=minimum) minimum_=minimum' is logically equivalent to 'minimum_=minimum'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:49] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\scroll_bar.cpp:48]: (style) The statement 'if (small_change_!=small_change) small_change_=small_change' is logically equivalent to 'small_change_=small_change'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\switch_button_renderer.h:28]: (information) The code 'class switch_button_renderer static_ {' is not handled. You can use -I or --include to add handling of this code.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\splitter.h:67] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\splitter.h:66]: (style) The statement 'if (min_size_!=min_size) min_size_=min_size' is logically equivalent to 'min_size_=min_size'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\splitter.h:80] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\splitter.h:79]: (style) The statement 'if (splitter_style_!=splitter_style) splitter_style_=splitter_style' is logically equivalent to 'splitter_style_=splitter_style'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\save_file_dialog.h:39] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\save_file_dialog.cpp:10]: (style, inconclusive) Function 'run_file_dialog' argument 1 names different: declaration 'hwnd_owner' definition 'owner'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme.h:87] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\theme.cpp:7]: (style, inconclusive) Function 'theme_from_name' argument 1 names different: declaration 'theme_name' definition 'name'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_images.h:63] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\theme_images.cpp:97]: (style, inconclusive) Function 'theme_from_name' argument 1 names different: declaration 'theme_name' definition 'name'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_colors.h:99] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\theme_colors.cpp:608]: (style, inconclusive) Function 'theme_from_name' argument 1 names different: declaration 'theme_color_name' definition 'name'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar_button.cpp:33] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar_button.cpp:32]: (style) The statement 'if (text_!=value) text_=value' is logically equivalent to 'text_=value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar_button.cpp:43] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar_button.cpp:42]: (style) The statement 'if (image_index_!=value) image_index_=value' is logically equivalent to 'image_index_=value'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\theme_renderers.h:78] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\theme_renderers.cpp:221]: (style, inconclusive) Function 'theme_from_name' argument 1 names different: declaration 'theme_name' definition 'name'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\track_bar.cpp:78] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\track_bar.cpp:80]: (style) Variable 'value_' is reassigned a value before the old one has been used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\toggle_button.cpp:38] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\toggle_button.cpp:37]: (style) The statement 'if (auto_check_!=auto_check) auto_check_=auto_check' is logically equivalent to 'auto_check_=auto_check'.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar.cpp:18]: (style) Struct 'parent_client_size_guard' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\tool_bar.cpp:237]: (style) Parameter 'message' can be declared with const
[C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\up_down_button.cpp:64] -> [C:\Users\bader\Desktop\xtd\src\xtd.forms\src\xtd\forms\up_down_button.cpp:66]: (style) Variable 'value_' is reassigned a value before the old one has been used.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\vertical_control_layout_style.h:27]: (style) Class 'vertical_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\vertical_control_layout_style.h:30]: (style) Class 'vertical_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\vertical_control_layout_style.h:33]: (style) Class 'vertical_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\vertical_control_layout_style.h:44]: (style) Class 'vertical_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms\include\xtd\forms\vertical_control_layout_style.h:55]: (style) Class 'vertical_control_layout_style' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\window_messages.cpp:9]: (style, inconclusive) Technically the member function '__message_sender__::operator()' can be const.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\control_wrapper_code.h:41]: (style) Class 'post_process_event' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_user_window.h:40]: (style) Class 'wx_user_window' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_button.h:31]: (style) Class 'wx_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_check_box.h:30]: (style) Class 'wx_check_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_checked_list_box.h:24]: (style) Class 'wx_checked_list_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\checked_list_box.cpp:108]: (style) Consider using std::copy algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_choice.h:24]: (style) Class 'wx_choice' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_collapsible_panel.h:25]: (style) Class 'wx_collapsible_panel' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_color_picker.h:24]: (style) Class 'wx_color_picker' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_combo_box.h:24]: (style) Class 'wx_combo_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_command_link_button.h:30]: (style) Class 'wx_command_link_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\cursors.cpp:21]: (information) Skipping configuration '__XTD_RESOURCES_PATH__' since the value of '__XTD_RESOURCES_PATH__' is unknown. Use -D if you want to check it. You can use -U to skip it explicitly.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_date_time_picker.h:26]: (style) Class 'wx_date_time_picker' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_domain_up_down.h:36]: (style) Class 'wxDomainSpinCtrl' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_domain_up_down.h:107]: (style) Class 'wx_domain_up_down' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_control.h:21]: (style) Class 'wx_control' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_control.h:23]: (style) C-style pointer casting
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_font_picker.h:23]: (style) Class 'wx_font_picker' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_form.h:67]: (style) Class 'wx_form' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_form.h:73]: (style) C-style pointer casting
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_form.h:74]: (style) C-style pointer casting
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_group_box.h:112]: (style) Class 'wx_group_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_label.h:28]: (style) Class 'wx_label' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_light_button.h:31]: (style) Class 'wx_light_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_list_box.h:24]: (style) Class 'wx_list_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_loading_indicator.h:27]: (style) Class 'wx_loading_indicator' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_month_calendar.h:24]: (style) Class 'wx_month_calendar' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_numeric_up_down.h:26]: (style) Class 'wx_numeric_up_down' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_panel.h:24]: (style) Class 'wx_panel' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_picture_box.h:25]: (style) Class 'wx_picture_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_progress_bar.h:25]: (style) Class 'wx_progress_bar' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_radio_button.h:28]: (style) Class 'wx_radio_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_scroll_bar.h:25]: (style) Class 'wx_scroll_bar' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_switch_button.h:28]: (style) Class 'wx_switch_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_tab_control.h:25]: (style) Class 'wx_tab_control' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_tab_page.h:27]: (style) Class 'wx_tab_page' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_text_box.h:26]: (style) Class 'wx_text_box' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_toggle_button.h:28]: (style) Class 'wx_toggle_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_tool_bar.h:27]: (style) Class 'wx_tool_bar' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_track_bar.h:24]: (style) Class 'wx_track_bar' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_up_down_button.h:25]: (style) Class 'wx_up_down_button' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_user_control.h:25]: (style) Class 'wx_user_control' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\file_dialog.cpp:23]: (style) Class 'FileDialog' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\file_dialog.cpp:53]: (style) Consider using std::transform algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\folder_browser_dialog.cpp:76]: (style) Class 'DirDialog' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\src\xtd\forms\native\wxwidgets\list_box.cpp:86]: (style) Consider using std::copy algorithm instead of a raw loop.
[C:\Users\bader\Desktop\xtd\src\xtd.forms.native.wxwidgets\include\xtd\forms\native\wxwidgets\wx_timer.h:21]: (style) Class 'wx_timer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.tunit\src\xtd\tunit\__demangle_gcc.cpp:9]: (style) Class 'auto_delete_char_pointer' has a constructor with 1 argument that is not explicit.
[C:\Users\bader\Desktop\xtd\src\xtd.tunit\src\xtd\tunit\__demangle_win32.cpp:10] -> [C:\Users\bader\Desktop\xtd\src\xtd.tunit\src\xtd\tunit\__demangle_win32.cpp:11]: (style) Redundant initialization for 'pos'. The initialized value is overwritten before it is read.
[C:\Users\bader\Desktop\xtd\src\xtd.tunit\include\xtd\tunit\assert.h:37]: (error) Syntax Error: AST broken, 'assert' doesn't have two operands.
</details>