### PR TITLE
V0.1.0 beta add #include <algorithm> update tag/v0.1.1-beta

### DIFF
--- a/src/xtd.forms/include/xtd/forms/list_control.h
+++ b/src/xtd.forms/include/xtd/forms/list_control.h
@@ -4,6 +4,8 @@
 #pragma once
 #include "control.h"
 
+#include <algorithm>
+
 /// @brief The xtd namespace contains all fundamental classes to access Hardware, Os, System, and more.
 namespace xtd {
   /// @brief The xtd::forms namespace contains classes for creating Windows-based applications that take full advantage of the rich user interface features available in the Microsoft Windows operating system, Apple macOS and Linux like Ubuntu operating system.

--- a/src/xtd.forms/src/xtd/forms/horizontal_layout_panel.cpp
+++ b/src/xtd.forms/src/xtd/forms/horizontal_layout_panel.cpp
@@ -1,6 +1,8 @@
 #include <xtd/argument_exception.h>
 #include "../../../include/xtd/forms/horizontal_layout_panel.h"
 
+#include <algorithm>
+
 using namespace std;
 using namespace xtd;
 using namespace xtd::forms;

--- a/src/xtd.forms/src/xtd/forms/vertical_layout_panel.cpp
+++ b/src/xtd.forms/src/xtd/forms/vertical_layout_panel.cpp
@@ -1,6 +1,8 @@
 #include <xtd/argument_exception.h>
 #include "../../../include/xtd/forms/vertical_layout_panel.h"
 
+#include <algorithm>
+
 using namespace std;
 using namespace xtd;
 using namespace xtd::forms;


### PR DESCRIPTION
when build tag/v0.1.1-beta in visual studio 2022, some errors:
xtd\v0.1.1-beta\source\xtd\src\xtd.forms\include\xtd\forms\list_control.h(33,18): error C2039: 'sort': is not a member of 'std';
xtd\src\xtd.forms\src\xtd\forms\horizontal_layout_panel.cpp(40,36): error C3861: 'count_if': identifier not found
xtd\src\xtd.forms\src\xtd\forms\vertical_layout_panel.cpp(40,36): error C3861: 'count_if': identifier not found