### PR TITLE
 Prevent flushing when auto_flush_out() is false 

### DIFF
--- a/src/xtd.core/src/xtd/console.cpp
+++ b/src/xtd.core/src/xtd/console.cpp
@@ -405,6 +405,6 @@ void console::write_(const string& value) {
 
 void console::write_line_(const string& value) {
   auto lock = std::lock_guard<std::recursive_mutex> {__console_mutex__};
-  out << value << std::endl;
+  out << value << '\n';
   if (auto_flush_out()) out.flush();
 }


### PR DESCRIPTION
Hello!
`std::endl` seems to put a new line and flushes the stream. 
Maybe `'\n'` will be enough in this case to avoid flushing when auto_flush_out() is false.
