### PR TITLE
Fix EXIT_status source

### DIFF
--- a/src/xtd.core/include/xtd/exit_status.hpp
+++ b/src/xtd.core/include/xtd/exit_status.hpp
@@ -14,7 +14,7 @@ namespace xtd {
   /// xtd.core
   /// @ingroup xtd_core
   /// @remarks Each of the above values represents a constant, which represent different exit status of to the program.
-  /// @remarks For more information about exit_status, see [EXIT_status](]https://en.cppreference.com/w/cpp/utility/program/EXIT_status).
+  /// @remarks For more information about exit_status, see [EXIT_status](https://en.cppreference.com/w/cpp/utility/program/EXIT_status).
   enum class exit_status {
     /// @brief Successful execution of a program. Is equal to [EXIT_SUCCESS](https://en.cppreference.com/w/cpp/utility/program/EXIT_status).
     success = EXIT_SUCCESS,


### PR DESCRIPTION
## PR Summary
This small PR fixes the `EXIT_status` reference. Relevant docs page: https://gammasoft71.github.io/xtd/reference_guides/latest/group__xtd__core.html