### PR TITLE
Fix `successfullly` -> `successfully` typo

### DIFF
--- a/docs/xtd_explanations.md
+++ b/docs/xtd_explanations.md
@@ -391,7 +391,7 @@ Or enable options in CMake-gui.
 
 #### Notes
 
-* Currently, there are +/- 11000 unit tests executed successfullly and 0 failed.
+* Currently, there are +/- 11000 unit tests executed successfully and 0 failed.
 * There are many missing. But the goal is to complete them as much as possible to have a complete coverage.
 
 ## Continuous integration builds


### PR DESCRIPTION
Line 394 of `docs/xtd_explanations.md` has `successfullly` (extra l).